### PR TITLE
Render metadata info in detail view

### DIFF
--- a/app/components/metadata-info.js
+++ b/app/components/metadata-info.js
@@ -1,0 +1,36 @@
+import { computed } from '@ember/object';
+import Component from '@ember/component';
+import { task, timeout } from 'ember-concurrency';
+import { inject } from '@ember/service';
+
+export default Component.extend({
+  init(){
+    this._super(...arguments);
+    this.fetchMetadata.perform();
+  },
+
+  didReceiveAttrs(){
+    this.fetchMetadata.perform();
+  },
+
+  ajax: inject(),
+
+  fetchMetadata: task( function * () {
+    const hash = this.get('hit.hash');
+
+    yield timeout( 50 );
+
+    if( !hash ) return;
+
+    const response = yield this.ajax.request(`https://api.ipfs-search.com/v1/metadata/${hash}`);
+    this.set('metadata', response.metadata);
+  } ).restartable(),
+
+  tableContents: computed('metadata', function() {
+    const metadataObject = this.get("metadata") || {};
+
+    return Object.entries( metadataObject ).map( ([key, values]) => {
+      return { key: key, valueString: values.join(",") };
+    } );
+  })
+});

--- a/app/components/search-hit-card.js
+++ b/app/components/search-hit-card.js
@@ -4,6 +4,7 @@ import moment from 'moment';
 
 export default Component.extend({
   tagName: '',
+  showMetadata: false,
 
   cardOpen: computed( 'more', 'forceExpand', function() {
     return this.more || this.forceExpand;

--- a/app/templates/components/metadata-info.hbs
+++ b/app/templates/components/metadata-info.hbs
@@ -1,15 +1,22 @@
 {{#if fetchMetadat.isRunning}}
   ...loading metadata...
 {{else}}
-  <table>
-    <tr>
-      <th>Key</th><th>Values</th>
-    </tr>
-    {{#each tableContents as |row|}}
-      <tr>
-        <td>{{row.key}}</td>
-        <td>{{row.valueString}}</td>
-      </tr>
-    {{/each}}
-  </table>
+  <div class="table-responsive">
+    <table class="table table-sm table-hover">
+      <thead class="thead-dark">
+        <tr>
+          <th scope="col">Key</th>
+          <th scope="col">Values</th>
+        </tr>
+      </thead>
+      <tbody>
+      {{#each tableContents as |row|}}
+        <tr>
+          <td scope="row" class="bg-light">{{row.key}}</td>
+          <td scope="row">{{row.valueString}}</td>
+        </tr>
+      {{/each}}
+      </tbody>
+    </table>
+  </div>
 {{/if}}

--- a/app/templates/components/metadata-info.hbs
+++ b/app/templates/components/metadata-info.hbs
@@ -1,0 +1,15 @@
+{{#if fetchMetadat.isRunning}}
+  ...loading metadata...
+{{else}}
+  <table>
+    <tr>
+      <th>Key</th><th>Values</th>
+    </tr>
+    {{#each tableContents as |row|}}
+      <tr>
+        <td>{{row.key}}</td>
+        <td>{{row.valueString}}</td>
+      </tr>
+    {{/each}}
+  </table>
+{{/if}}

--- a/app/templates/components/search-hit-card.hbs
+++ b/app/templates/components/search-hit-card.hbs
@@ -18,9 +18,9 @@
   {{#modal.body}}
     {{#if showMetadata}}
       {{metadata-info hit=hit}}
-      <span {{action (mut showMetadata) false}}>Hide metadata</span>
+      <span {{action (mut showMetadata) false}} class="btn btn-light">Hide metadata</span>
     {{else}}
-      <span {{action (mut showMetadata) true}}>Show metadata</span>
+      <span {{action (mut showMetadata) true}} class="btn btn-light">Show metadata</span>
     {{/if}}
 
     <p>{{{hit.description}}}</p>

--- a/app/templates/components/search-hit-card.hbs
+++ b/app/templates/components/search-hit-card.hbs
@@ -16,6 +16,12 @@
     </h5>
   {{/modal.header}}
   {{#modal.body}}
+    {{#if showMetadata}}
+      {{metadata-info hit=hit}}
+      <span {{action (mut showMetadata) false}}>Hide metadata</span>
+    {{else}}
+      <span {{action (mut showMetadata) true}}>Show metadata</span>
+    {{/if}}
 
     <p>{{{hit.description}}}</p>
 

--- a/tests/integration/components/metadata-info-test.js
+++ b/tests/integration/components/metadata-info-test.js
@@ -1,0 +1,26 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | metadata-info', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    await render(hbs`{{metadata-info}}`);
+
+    assert.equal(this.element.textContent.trim(), '');
+
+    // Template block usage:
+    await render(hbs`
+      {{#metadata-info}}
+        template block text
+      {{/metadata-info}}
+    `);
+
+    assert.equal(this.element.textContent.trim(), 'template block text');
+  });
+});


### PR DESCRIPTION
In issue #7 there is a request to render the metadata in the detail view.  This PR represents that state.

Functionally, the thing works.  It doesn't cache results, but that's likely not the biggest problem.

@vandrongelen Can you make this pretty?

Related files for design:

- app/templates/components/search-hit-card.hbs for show/hide
- app/templates/components/metadata-info.hbs for rendered metadata table