### PR TITLE
Support for iOS

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -12,6 +12,12 @@
 }
 // END to be designed
 
+.clickable-menu-items {
+  .dropdown-item {
+    cursor: pointer;
+  }
+}
+
 .btn-group > .input-group-append:not(:last-child) {
   @include border-right-radius(0);
 }

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -18,6 +18,10 @@
   }
 }
 
+.page-link {
+  cursor: pointer;
+}
+
 .btn-group > .input-group-append:not(:last-child) {
   @include border-right-radius(0);
 }

--- a/app/styles/includes/helpers.scss
+++ b/app/styles/includes/helpers.scss
@@ -23,7 +23,6 @@ input[type="text"], textarea, .list-group-item {
 
 // remove transparent color from dropdown menu button
 .btn-outline-secondary, .dropdown {
-  background-color: none !important;
   background-color: white;
 }
 

--- a/app/templates/components/search-input/raw-search.hbs
+++ b/app/templates/components/search-input/raw-search.hbs
@@ -9,7 +9,7 @@
     {{/dd.button}}
 
     <div class="input-group-append">
-      {{#dd.menu class="dropdown-menu dropdown-menu-right" as |menu|}}
+      {{#dd.menu class="dropdown-menu dropdown-menu-right clickable-menu-items" as |menu|}}
         {{#menu.item active=(eq newSearchKind "file") action=(action "changeKind" "file")}}
           Any file
         {{/menu.item}}

--- a/package.json
+++ b/package.json
@@ -20,9 +20,10 @@
   "devDependencies": {
     "@ember/jquery": "^0.5.2",
     "@ember/optional-features": "^0.6.3",
-    "bootstrap": "^4.0.0",
+    "bootstrap": "^4.3.1",
     "broccoli-asset-rev": "^2.7.0",
     "ember-ajax": "^3.1.0",
+    "ember-bootstrap": "^2.6.0",
     "ember-cli": "~3.5.1",
     "ember-cli-app-version": "^3.2.0",
     "ember-cli-babel": "^6.16.0",
@@ -62,7 +63,6 @@
     "node": "6.* || 8.* || >= 10.*"
   },
   "dependencies": {
-    "ember-bootstrap": "^1.2.0",
     "npm": "^5.7.1"
   }
 }


### PR DESCRIPTION
@vandrongelen pointed out that iOS support was lacking.  Good find!  A solution was proposed to fix the search selection with JQuery.  In researching the issue, I've chosen an alternative implementation which doesn't interfere with Single Page App use and which I could understand (apologies for the duplicate work).

We're upgrading the ember-bootstrap version so we're certainly in an up-to-date state.  Don't forget to npm install when test-driving this.

The specific iOS issue can be resolved by giving the clickable element the `cursor: pointer` style.  This ensures iOS triggers click events on that item, making the action fire.  Thereby letting iOS users select the kind of search they want.

We are going over the other elements of the UI on the iOS tablet and we're updating the necessary pieces.  This should not be merged before things have settled.