### PR TITLE
Support multiple video gateways

### DIFF
--- a/app/components/search-hit/details.hbs
+++ b/app/components/search-hit/details.hbs
@@ -20,7 +20,11 @@
     {{/if}}
     {{#if (eq "video" (hit-kind @hit))}}
       <div class="embed-responsive embed-responsive-16by9">
-        <video class="embed-responsive-item" src={{hit-url @hit}} controls="" preload="metadata" />
+        <video class="embed-responsive-item" controls="" preload="metadata">
+          {{#each (hit-urls @hit) as |hitUrl|}}
+             <source src={{hitUrl}} >
+          {{/each}}
+        </video>
       </div>
     {{/if}}
     {{#if (eq "audio" (hit-kind @hit))}}

--- a/app/helpers/hit-urls.js
+++ b/app/helpers/hit-urls.js
@@ -1,0 +1,8 @@
+import { helper } from '@ember/component/helper';
+
+export default helper(function hitUrls([hit]/*, hash*/) {
+  return [
+    `https://gateway.ipfs.io/ipfs/${hit.hash}`,
+    `https://clowdflare-ipfs.com/ipfs/${hit.hash}`
+  ];
+});

--- a/tests/integration/helpers/hit-urls-test.js
+++ b/tests/integration/helpers/hit-urls-test.js
@@ -1,0 +1,17 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Helper | hit-urls', function(hooks) {
+  setupRenderingTest(hooks);
+
+  // Replace this with your real tests.
+  test('it renders', async function(assert) {
+    this.set('inputValue', '1234');
+
+    await render(hbs`{{hit-urls inputValue}}`);
+
+    assert.equal(this.element.textContent.trim(), '1234');
+  });
+});


### PR DESCRIPTION
As suggested in #45, offering multiple video gateways will allow us to
embed the videos.  We now support both the mainstream gateway.ipfs.io,
as well as cloudflare's ipfs gateway.  The combination of these two
should provide better support.

We could use a similar approach in other places.  This is the one
where the effect is the most apparent.