### PR TITLE
Add copy hash button

### DIFF
--- a/app/components/search-hit/details.hbs
+++ b/app/components/search-hit/details.hbs
@@ -88,7 +88,9 @@
     <h5>Direct link</h5>
     <ul>
       <li class="row mt-3">
-        <a target="_blank" href="{{ hash-url @hit.hash }}">{{ @hit.hash }}</a>&nbsp;<a href="{{ hash-url @hit.hash true }}"><i class="fas fa-download"></i></a>
+        <a target="_blank" href="{{ hash-url @hit.hash }}" title="View on gateway">{{ @hit.hash }}</a>
+        <a href="{{ hash-url @hit.hash true }}" title="Download from gateway"><i class="fas fa-download"></i></a>
+        <button class="btn" onclick={{action "copyHitHash"}} tooltip="Copy hash to clipboard"><i class="fas fa-copy"></i></button>
       </li>
     </ul>
 

--- a/app/components/search-hit/details.js
+++ b/app/components/search-hit/details.js
@@ -1,5 +1,10 @@
 import Component from '@glimmer/component';
 
 export default class SearchHitDetailsComponent extends Component {
-
+    actions = {
+        async copyHitHash() {
+            await navigator.clipboard.writeText(this.args.hit.hash);
+            return false;
+        }
+    }
 }


### PR DESCRIPTION
I'm was using ipfs-search to find video's that would work on my own website (ipfs.video) and was missing a "copy hash to clipboard" option.

I've added this, however I'm having some issues without layouting and color of the button.

I think the copy hash button is a generally usefull feature, but it would also be nice if video's did not rely on the gateway so much. I'd be happy to see if I could extract the video decoding into a separate library or iframe to have supported video's run directly from ipfs.

Anyway, let me know what I could do to change the layouting of the button to look like a link.